### PR TITLE
fix,chore/ add api fetch on opening direct service page link, organize css

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -2,7 +2,6 @@ import { MainPage } from "./components/MainPage";
 import { ServicePage } from "./components/ServicePage";
 import { Routes, Route } from "react-router-dom";
 import { DataProvider } from "./contexts/DataContext";
-import "./styles/App.css";
 import { NavbarProvider } from "./contexts/NavbarContext";
 
 const App = () => {

--- a/ui/src/components/ServicePage.jsx
+++ b/ui/src/components/ServicePage.jsx
@@ -35,7 +35,6 @@ export const ServicePage = () => {
       }
     } else {
       setNoDataFound(true);
-      console.log("no data found");
     }
   }, []);
 
@@ -52,7 +51,6 @@ export const ServicePage = () => {
         setPageData(service, providerData.apis);
       } else {
         setNoDataFound(true);
-        console.log("no data found");
       }
     }
   }, [data, loading, provider, service, setPageData]);

--- a/ui/src/components/ServicePage.jsx
+++ b/ui/src/components/ServicePage.jsx
@@ -1,9 +1,11 @@
+import axios from "axios";
 import { useCallback, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useDataContext } from "../contexts/DataContext";
 
 import "../styles/components/ServicePage.css";
 import { useNavbarContext } from "../contexts/NavbarContext";
+import { API_GURU_BASE_URL } from "../utils/constants";
 
 export const ServicePage = () => {
   const { provider, service } = useParams();
@@ -50,7 +52,15 @@ export const ServicePage = () => {
       if (providerData) {
         setPageData(service, providerData.apis);
       } else {
-        setNoDataFound(true);
+        axios
+          .get(`${API_GURU_BASE_URL}/${provider}.json`)
+          .then((res) => {
+            setPageData(service, res.data.apis);
+          })
+          .catch((error) => {
+            setNoDataFound(true);
+            console.error(error);
+          });
       }
     }
   }, [data, loading, provider, service, setPageData]);

--- a/ui/src/styles/App.css
+++ b/ui/src/styles/App.css
@@ -1,3 +1,0 @@
-.app {
-  height: 100vh;
-}

--- a/ui/src/styles/components/ServicePage.css
+++ b/ui/src/styles/components/ServicePage.css
@@ -4,6 +4,7 @@
   align-items: center;
   color: white;
   height: 100%;
+  overflow: auto;
 }
 
 h1, h2 {

--- a/ui/src/styles/global.css
+++ b/ui/src/styles/global.css
@@ -13,6 +13,10 @@ code {
     monospace;
 }
 
+.app {
+  height: 100vh;
+}
+
 .btn-primary {
   color: white;
   background-color: #049DD2;


### PR DESCRIPTION
## Changelog
- handle case where we directly go to a link which is not yet stored in `data` state (this includes those providers not part of the first N providers in list, where N = number of providers initially loaded in main page navbar
  - add data fetching step to check if data exists
- organize App css file